### PR TITLE
fix: Import PropTypes into Breadcrumbs

### DIFF
--- a/src/components/BreadCrumb/BreadCrumb.js
+++ b/src/components/BreadCrumb/BreadCrumb.js
@@ -1,5 +1,6 @@
 import './BreadCrumb.css';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 function BreadCrumb({ setSelectedMovie }) {
   const clickHandler = (event) => {


### PR DESCRIPTION
# Rancid Tomatillos - Mod 3

## Description of the changes proposed in this pull request:

Import PropTypes into Breadcrumbs

## Contributors to this pull request:
 - [x] Marisa Wyatt / [@marisa5280](https://github.com/Marisa5280)
 - [x] Jan McSorley / [@jmcsorle](https://github.com/jmcsorle)
 
## Does this pull request reference any related issues? If so please list the issue(s) below:
 - 
